### PR TITLE
Fix UnicodeDecodeError when downloading a document image

### DIFF
--- a/onfido/rest.py
+++ b/onfido/rest.py
@@ -217,7 +217,8 @@ class RESTClientObject(object):
 
             # In the python 3, the response.data is bytes.
             # we need to decode it to string.
-            if six.PY3:
+            if (six.PY3 and
+                    r.urllib3_response.headers.get('Content-Transfer-Encoding', '') != 'binary'):
                 r.data = r.data.decode('utf8')
 
             # log response body


### PR DESCRIPTION
Document image data is transferred as binary and cannot be decoded to string, so I just added a check using Content-Transfer-Encoding header.

```
/usr/local/lib/python3.6/site-packages/onfido/rest.py in GET(self, url, headers, query_params, _preload_content, _request_timeout)
    235                             _preload_content=_preload_content,
    236                             _request_timeout=_request_timeout,
--> 237                             query_params=query_params)
    238
    239     def HEAD(self, url, headers=None, query_params=None, _preload_content=True,

/usr/local/lib/python3.6/site-packages/onfido/rest.py in request(self, method, url, query_params, headers, body, post_params, _preload_content, _request_timeout)
    219             # we need to decode it to string.
    220             if six.PY3:
--> 221                 r.data = r.data.decode('utf8')
    222
    223             # log response body

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

I just saw that tests are empty, Are you going to do some changes there? I can try to add some testing for this part.

Regards.